### PR TITLE
HOTFIX-thread.c

### DIFF
--- a/devices/timer.c
+++ b/devices/timer.c
@@ -142,6 +142,7 @@ timer_interrupt (struct intr_frame *args UNUSED) {
 			break;
 		}
 	}
+	thread_get_priority();
 }
 
 static bool compare_wake_time (const struct list_elem *a, const struct list_elem *b, void *aux) {

--- a/threads/thread.c
+++ b/threads/thread.c
@@ -323,7 +323,11 @@ int
 thread_get_priority (void) {
 	list_sort(&ready_list, compare_priority, NULL);
 	if ((!list_empty(&ready_list))&&(list_entry (list_front(&ready_list), struct thread, elem)->priority >= thread_current()->priority))
-		thread_yield();
+		if (!intr_context()) {
+			thread_yield();
+		} else {
+			intr_yield_on_return();
+		}
 	return thread_current ()->priority;
 }
 


### PR DESCRIPTION
interrupt context에서 sema_up()을 호출하는 경우가 있는데
interrupt context에서는 thread_yield()를 직접 호출하면 안되어 수정했습니다.
thread.c만 고치면 되는데 timer.c는 문제는 없는데 깨우고 바로 yield하도록 수정했습니다.